### PR TITLE
Fix the delimiter error of post categories

### DIFF
--- a/_includes/_macro/post.html
+++ b/_includes/_macro/post.html
@@ -107,7 +107,7 @@
                 </span>
 
                 {% assign cat_length = post.categories.size %}
-                {% if cat_length > 1 and loop.index != cat_length %}
+                {% if cat_length > 1 and forloop.index != cat_length %}
                   {{ __.symbol.comma }}
                 {% endif %}
               {% endfor %}


### PR DESCRIPTION
一篇文章有多个分类时，最后一个分类后面多一个逗号。问题由变量名称错误导致，应该将 loop 改为 forloop。