### PR TITLE
添加 valine 评论系统

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -441,6 +441,13 @@ gitalk:
   repo: # colingpt.github.io
   owner: # colingpt
   admin: # colingpt
+  
+# Support for valine comments system.  
+valine:
+  enable: false
+  appid: 
+  appkey: 
+  placeholder: "评论"
 
 # Baidu Share
 # Available value:

--- a/_config.yml
+++ b/_config.yml
@@ -445,8 +445,8 @@ gitalk:
 # Support for valine comments system.  
 valine:
   enable: false
-  appid: 
-  appkey: 
+  appid: k7xSshfgijq6z206P2xMMj24-ijGaoHsz
+  appkey: 9YgVFuihluSWMtWoLgeXuL
   placeholder: "评论"
 
 # Baidu Share

--- a/_includes/_partials/comments.html
+++ b/_includes/_partials/comments.html
@@ -34,6 +34,8 @@
       <div id="SOHUCS"></div>
     {% elsif site.wildfire.enable %}
       <div class="wildfire_thread"></div>
+	{% elsif site.valine.enable %}
+	  <div id="vcomments"></div>
     {% endif %}
   </div>
 {% endif %}

--- a/_includes/_third-party/comments/index.html
+++ b/_includes/_third-party/comments/index.html
@@ -7,3 +7,4 @@
 {% include _third-party/comments/livere.html %}
 {% include _third-party/comments/changyan.html %}
 {% include _third-party/comments/wildfire.html %}
+{% include _third-party/comments/valine.html %}

--- a/_includes/_third-party/comments/valine.html
+++ b/_includes/_third-party/comments/valine.html
@@ -1,0 +1,17 @@
+{% unless site.duoshuo_shortname
+  or site.disqus_shortname
+  or site.hypercomments_id
+  or site.gentie_productKey
+  or site.duoshuo and site.duoshuo.shortname %}
+{% if site.valine.enable %}
+<script src="//cdn1.lncld.net/static/js/3.0.4/av-min.js"></script>
+<script src='//unpkg.com/valine/dist/Valine.min.js'></script>
+<script>
+    new Valine({
+        el: '#comments',
+        app_id: '{{ site.valine.appid }}',  
+        app_key: '{{ site.valine.appkey }}', 
+        placeholder:'{{ site.valine.placeholder }}'    
+    });</script>
+{% endif %}
+{% endunless %}


### PR DESCRIPTION
试了提供的几个评论系统，由于是国外的，加载都比较慢，所有就找了个国内的。
使用方式：
1、到 https://leancloud.cn/ 注册；
2、创建一个应用；
3、选择刚刚创建的应用 -> 设置 -> 安全中心 -> Web 安全域名 设置自己的域名，如：https://xxx.github.io/ ；
4、选择刚刚创建的应用 -> 设置 -> 应用 Key ，就能看到你的 APP ID 和 APP KEY 了,将 _config.yml 中
```
valine:
  enable: true
  appid: 
  appkey: 
  placeholder: "评论"
```
的 appid 和 appkey 换成自己的 APP ID 和 APP KEY 即可。