### PR TITLE
fix bug: postlist with picture post

### DIFF
--- a/_includes/_macro/post.html
+++ b/_includes/_macro/post.html
@@ -1,5 +1,6 @@
 {% comment %} post(post, is_index, post_extra_class) {% endcomment %}
 
+  {% assign headlessPost = false %}
   {% if 'quote, picture' contains post.type %}
     {% assign headlessPost = true %}
   {% endif %}


### PR DESCRIPTION
All the following post after a picture post will have no title section.
Set headlessPost = false